### PR TITLE
Updated style.

### DIFF
--- a/app/src/androidTest/java/com/petrulak/cleankotlin/di/component/ApplicationMockComponent.kt
+++ b/app/src/androidTest/java/com/petrulak/cleankotlin/di/component/ApplicationMockComponent.kt
@@ -6,9 +6,12 @@ import dagger.Component
 import javax.inject.Singleton
 
 @Singleton
-@Component(modules = arrayOf(
-    ApplicationMockModule::class,
-    InteractorMockModule::class))
+@Component(
+    modules = arrayOf(
+        ApplicationMockModule::class,
+        InteractorMockModule::class
+    )
+)
 interface ApplicationMockComponent : ApplicationComponent {
 
 }

--- a/app/src/androidTest/java/com/petrulak/cleankotlin/di/component/ViewMockComponent.kt
+++ b/app/src/androidTest/java/com/petrulak/cleankotlin/di/component/ViewMockComponent.kt
@@ -7,9 +7,12 @@ import com.petrulak.cleankotlin.ui.example2.Example2PresenterTest
 import dagger.Component
 
 @ViewScope
-@Component(dependencies = arrayOf(
-    ApplicationMockComponent::class),
-    modules = arrayOf(PresenterMockModule::class))
+@Component(
+    dependencies = arrayOf(
+        ApplicationMockComponent::class
+    ),
+    modules = arrayOf(PresenterMockModule::class)
+)
 interface ViewMockComponent {
 
     fun inject(item: Example2ActivityTest)

--- a/app/src/main/java/com/petrulak/cleankotlin/ui/example2/Example2Presenter.kt
+++ b/app/src/main/java/com/petrulak/cleankotlin/ui/example2/Example2Presenter.kt
@@ -13,7 +13,7 @@ class Example2Presenter
 @Inject
 constructor(private val getWeatherRemotelyUseCase: GetWeatherRemotelyUseCase) : BasePresenterImpl(), Example2Contract.Presenter {
 
-     var view: View? = null
+    var view: View? = null
 
     override fun attachView(view: View) {
         this.view = checkNotNull(view)
@@ -29,7 +29,11 @@ constructor(private val getWeatherRemotelyUseCase: GetWeatherRemotelyUseCase) : 
             .execute(city)
             .doOnSubscribe { setViewState(ViewState.Loading()) }
             .doFinally { setViewState(ViewState.LoadingFinished()) }
-            .subscribeWith(getDisposableSingleObserver({ setViewState(ViewState.Success(it)) }, { setViewState(ViewState.Error(it)) }))
+            .subscribeWith(
+                getDisposableSingleObserver(
+                    { setViewState(ViewState.Success(it)) },
+                    { setViewState(ViewState.Error(it)) })
+            )
         disposables.add(disposable)
     }
 

--- a/data/src/main/AndroidManifest.xml
+++ b/data/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.petrulak.cleankotlin" />
+<manifest package="com.petrulak.cleankotlin"/>

--- a/data/src/main/java/com/petrulak/cleankotlin/data/repository/WeatherRepositoryImpl.kt
+++ b/data/src/main/java/com/petrulak/cleankotlin/data/repository/WeatherRepositoryImpl.kt
@@ -17,10 +17,12 @@ import javax.inject.Singleton
 @Singleton
 class WeatherRepositoryImpl
 @Inject
-constructor(private val remoteSource: RemoteSource,
-            private val localSource: LocalSource,
-            private val weatherDtoMapper: Mapper<Weather, WeatherDto>,
-            private val weatherEntityMapper: Mapper<Weather, WeatherEntity>) : WeatherRepository {
+constructor(
+    private val remoteSource: RemoteSource,
+    private val localSource: LocalSource,
+    private val weatherDtoMapper: Mapper<Weather, WeatherDto>,
+    private val weatherEntityMapper: Mapper<Weather, WeatherEntity>
+) : WeatherRepository {
 
     override fun getWeatherForCityRemotely(city: String): Single<Weather> {
         return remoteSource

--- a/data/src/main/java/com/petrulak/cleankotlin/data/source/local/WeatherLocalSource.kt
+++ b/data/src/main/java/com/petrulak/cleankotlin/data/source/local/WeatherLocalSource.kt
@@ -13,8 +13,10 @@ import javax.inject.Singleton
 @Singleton
 class WeatherLocalSource
 @Inject
-constructor(private val db: WeatherDatabase,
-            private val mapper: WeatherEntityMapper) : LocalSource {
+constructor(
+    private val db: WeatherDatabase,
+    private val mapper: WeatherEntityMapper
+) : LocalSource {
 
     override fun save(weather: Weather): Completable {
         val item = mapper.reverse(weather)

--- a/data/src/test/java/com/petrulak/cleankotlin/data/mapper/WeatherEntityMapperTest.kt
+++ b/data/src/test/java/com/petrulak/cleankotlin/data/mapper/WeatherEntityMapperTest.kt
@@ -6,7 +6,7 @@ import org.junit.Assert
 import org.junit.Test
 
 
-class WeatherEntityMapperTest{
+class WeatherEntityMapperTest {
 
     val mapper = WeatherEntityMapper()
 

--- a/domain/src/main/java/com/petrulak/cleankotlin/domain/interactor/GetWeatherLocallyUseCaseImpl.kt
+++ b/domain/src/main/java/com/petrulak/cleankotlin/domain/interactor/GetWeatherLocallyUseCaseImpl.kt
@@ -11,8 +11,10 @@ import javax.inject.Singleton
 @Singleton
 class GetWeatherLocallyUseCaseImpl
 @Inject
-constructor(private val schedulerProvider: SchedulerProvider,
-            private val repository: WeatherRepository) : GetWeatherLocallyUseCase {
+constructor(
+    private val schedulerProvider: SchedulerProvider,
+    private val repository: WeatherRepository
+) : GetWeatherLocallyUseCase {
 
     private fun buildUseCase(city: String): Flowable<Weather> {
         return when (city.isEmpty()) {

--- a/domain/src/main/java/com/petrulak/cleankotlin/domain/interactor/GetWeatherRemotelyUseCaseImpl.kt
+++ b/domain/src/main/java/com/petrulak/cleankotlin/domain/interactor/GetWeatherRemotelyUseCaseImpl.kt
@@ -11,8 +11,10 @@ import javax.inject.Singleton
 @Singleton
 class GetWeatherRemotelyUseCaseImpl
 @Inject
-constructor(private val schedulerProvider: SchedulerProvider,
-            private val repository: WeatherRepository) : GetWeatherRemotelyUseCase {
+constructor(
+    private val schedulerProvider: SchedulerProvider,
+    private val repository: WeatherRepository
+) : GetWeatherRemotelyUseCase {
 
     private fun buildUseCase(city: String): Single<Weather> {
         return when (city.isEmpty()) {

--- a/domain/src/main/java/com/petrulak/cleankotlin/domain/interactor/GetWeatherUseCaseImpl.kt
+++ b/domain/src/main/java/com/petrulak/cleankotlin/domain/interactor/GetWeatherUseCaseImpl.kt
@@ -11,8 +11,10 @@ import javax.inject.Singleton
 @Singleton
 class GetWeatherUseCaseImpl
 @Inject
-constructor(private val schedulerProvider: SchedulerProvider,
-            private val repository: WeatherRepository) : GetWeatherUseCase {
+constructor(
+    private val schedulerProvider: SchedulerProvider,
+    private val repository: WeatherRepository
+) : GetWeatherUseCase {
 
     private fun buildUseCase(city: String): Flowable<Weather> {
         return when (city.isEmpty()) {

--- a/domain/src/main/java/com/petrulak/cleankotlin/domain/interactor/base/BaseInteractor.kt
+++ b/domain/src/main/java/com/petrulak/cleankotlin/domain/interactor/base/BaseInteractor.kt
@@ -15,7 +15,10 @@ abstract class BaseInteractor<T> {
 
     protected var disposables: CompositeDisposable = CompositeDisposable()
 
-    protected fun getDisposableSingleObserver(onNext: (T) -> Unit, onError: (Throwable) -> Unit = {}): DisposableSingleObserver<T> {
+    protected fun getDisposableSingleObserver(
+        onNext: (T) -> Unit,
+        onError: (Throwable) -> Unit = {}
+    ): DisposableSingleObserver<T> {
 
         return object : DisposableSingleObserver<T>() {
             override fun onSuccess(value: T) {
@@ -29,7 +32,10 @@ abstract class BaseInteractor<T> {
         }
     }
 
-    protected fun getDisposableCompletableObserver(onComplete: () -> Unit, onError: (Throwable) -> Unit = {}): DisposableCompletableObserver {
+    protected fun getDisposableCompletableObserver(
+        onComplete: () -> Unit,
+        onError: (Throwable) -> Unit = {}
+    ): DisposableCompletableObserver {
 
         return object : DisposableCompletableObserver() {
 

--- a/domain/src/main/java/com/petrulak/cleankotlin/domain/interactor/base/CompletableInteractor.kt
+++ b/domain/src/main/java/com/petrulak/cleankotlin/domain/interactor/base/CompletableInteractor.kt
@@ -4,7 +4,8 @@ import com.petrulak.cleankotlin.domain.executor.SchedulerProvider
 import io.reactivex.Completable
 
 abstract class CompletableInteractor<Parameters>(
-    private val schedulerProvider: SchedulerProvider) : BaseInteractor<Void>() {
+    private val schedulerProvider: SchedulerProvider
+) : BaseInteractor<Void>() {
 
     abstract fun buildUseCase(parameters: Parameters): Completable
 

--- a/domain/src/main/java/com/petrulak/cleankotlin/domain/interactor/base/FlowableInteractor.kt
+++ b/domain/src/main/java/com/petrulak/cleankotlin/domain/interactor/base/FlowableInteractor.kt
@@ -4,7 +4,8 @@ import com.petrulak.cleankotlin.domain.executor.SchedulerProvider
 import io.reactivex.Flowable
 
 abstract class FlowableInteractor<T, Parameters>(
-    private val schedulerProvider: SchedulerProvider) : BaseInteractor<T>() {
+    private val schedulerProvider: SchedulerProvider
+) : BaseInteractor<T>() {
 
     abstract fun buildUseCase(parameters: Parameters): Flowable<T>
 

--- a/domain/src/main/java/com/petrulak/cleankotlin/domain/interactor/base/SingleInteractor.kt
+++ b/domain/src/main/java/com/petrulak/cleankotlin/domain/interactor/base/SingleInteractor.kt
@@ -4,7 +4,8 @@ import com.petrulak.cleankotlin.domain.executor.SchedulerProvider
 import io.reactivex.Single
 
 abstract class SingleInteractor<T, Parameters>(
-    private val schedulerProvider: SchedulerProvider) : BaseInteractor<T>() {
+    private val schedulerProvider: SchedulerProvider
+) : BaseInteractor<T>() {
 
     abstract fun buildUseCase(parameters: Parameters): Single<T>
 


### PR DESCRIPTION
Use Kotlin default coding style/conventions.
`http://kotlinlang.org/docs/reference/coding-conventions.html`
```
Note: To configure the IntelliJ formatter according to this style guide, please install Kotlin plugin version 1.2.20-eap-33 or newer, go to Settings | Editor | Code Style | Kotlin, click on "Set from…" link in the upper right corner, and select "Predefined style / Kotlin style guide" from the menu.
```